### PR TITLE
Fixed redirect for index with getServerSideProps

### DIFF
--- a/lib/allNextJsPages.js
+++ b/lib/allNextJsPages.js
@@ -55,7 +55,7 @@ const getAllPages = () => {
     // the JSON data to the Netlify Function.
     const dataRoute = dataRoutes.find(({ page }) => page === route);
     if (dataRoute)
-      alternativeRoutes.push(join("/_next/data", buildId, `${route}.json`));
+      alternativeRoutes.push(join("/_next/data", buildId, `${route === "/" ? "/index" : route}.json`));
 
     pages.push(new Page({ route, type, filePath, alternativeRoutes }));
   });


### PR DESCRIPTION
When adding `getServerSideProps` to `index.js`, `next-on-netlify` would add
```
/_next/data/.../.json  /.netlify/functions/next_index  200
```
to the `out_publish/_redirects` file. 

I added a fix so that
```
/_next/data/.../index.json  /.netlify/functions/next_index  200
``` 
will be written instead.