### PR TITLE
Copy host property from headers to multiValueHeaders

### DIFF
--- a/lib/netlifyFunctionTemplate.js
+++ b/lib/netlifyFunctionTemplate.js
@@ -31,6 +31,12 @@ exports.handler = (event, context, callback) => {
     process.env.BINARY_SUPPORT = "yes";
   }
 
+  // When running at the netlify, the header "host" is not set in
+  // multiValueHeaders. So we manually set this property.
+  if(!event.multiValueHeaders.hasOwnProperty('host')) {
+    event.multiValueHeaders['host'] = [event.headers['host']]
+  }
+
   // Get the request URL
   const { path } = event;
   console.log("[request]", path);


### PR DESCRIPTION
Hi everyone, looking for a solution to to resolve #40 I did my fork, and case this is acceptable in the project, I will let my PR :smile: 

This PR takes the host property from `event.headers` and copy to host in `event.multiValueHeaders`.
I'm opening this PR just in case you think this a good way to solve this problem.

PS: If you think that has another way, just give the suggest and I will take a look and implement.
PS: I don't know if this change specifically needs some test, if need, what exactly I can test. 