### PR TITLE
Copy host property from headers to multiValueHeaders

### DIFF
--- a/lib/templates/netlifyFunction.js
+++ b/lib/templates/netlifyFunction.js
@@ -31,6 +31,12 @@ exports.handler = (event, context, callback) => {
     process.env.BINARY_SUPPORT = "yes";
   }
 
+  // When running at the netlify, the header "host" is not set in
+  // multiValueHeaders. So we manually set this property.
+  if(!event.multiValueHeaders.hasOwnProperty('host')) {
+    event.multiValueHeaders['host'] = [event.headers['host']]
+  }
+
   // Get the request URL
   const { path } = event;
   console.log("[request]", path);

--- a/lib/templates/netlifyFunction.js
+++ b/lib/templates/netlifyFunction.js
@@ -31,8 +31,9 @@ exports.handler = (event, context, callback) => {
     process.env.BINARY_SUPPORT = "yes";
   }
 
-  // When running at the netlify, the header "host" is not set in
-  // multiValueHeaders. So we manually set this property.
+  // When running on netlify, the header "host" is not set in
+  // multiValueHeaders so we manually set it here.
+  // TO-DO: @lindsaylevine/@cassidoo remove after netlify supports internally
   if(!event.multiValueHeaders.hasOwnProperty('host')) {
     event.multiValueHeaders['host'] = [event.headers['host']]
   }


### PR DESCRIPTION
extends/fixes conflict in https://github.com/netlify/next-on-netlify/pull/42

---

Hi everyone, looking for a solution to to resolve #40 I did my fork, and case this is acceptable in the project, I will let my PR 😄

This PR takes the host property from event.headers and copy to host in event.multiValueHeaders.
I'm opening this PR just in case you think this a good way to solve this problem.

PS: If you think that has another way, just give the suggest and I will take a look and implement.
PS: I don't know if this change specifically needs some test, if need, what exactly I can test.