### PR TITLE
Update to prevent #55 from occurring again

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ It's super simple. Just create a `next.config.js` file and write the following:
 
 module.exports = {
   // Target must be serverless
+  target: "serverless",
+};
+```
+
+If binaries are needed in the deployment the following configuration is needed ([Prisma](https://github.com/prisma/prisma) is an example):
+
+```js
+// next.config.js
+
+module.exports = {
+  // Target must be experimental-serverless-trace
+  // Your build time will be longer with this option
   target: "experimental-serverless-trace",
 };
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It's super simple. Just create a `next.config.js` file and write the following:
 
 module.exports = {
   // Target must be serverless
-  target: "serverless",
+  target: "experimental-serverless-trace",
 };
 ```
 


### PR DESCRIPTION
This change in the readme is to help future developers not have binary issues across lambda functions created by the next build command.