### PR TITLE
Properly copy Netlify Trigger Functions  

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,31 @@ const FUNCTION_TEMPLATE_PATH = join(
   "netlifyFunction.js"
 );
 
+// Netlify watches for these functions that trigger from a variety of events
+const NETLIFY_DEPLOY_FUNCTIONS = [
+  "deploy-building",
+  "deploy-succeeded",
+  "deploy-failed",
+  "deploy-locked",
+  "deploy-unlocked",
+];
+const NETLIFY_SPLIT_TEST_FUNCTIONS = [
+  "split-test-activated",
+  "split-test-deactivated",
+  "split-test-modified",
+];
+const NETLIFY_FORM_FUNCTIONS = ["submission-created"];
+const NETLIFY_IDENTITY_FUNCTIONS = [
+  "identity-validate",
+  "identity-signup",
+  "identity-login",
+];
+const NETLIFY_TRIGGER_FUNCTIONS = NETLIFY_DEPLOY_FUNCTIONS.concat(
+  NETLIFY_SPLIT_TEST_FUNCTIONS,
+  NETLIFY_FORM_FUNCTIONS,
+  NETLIFY_IDENTITY_FUNCTIONS
+);
+
 // This is the file where custom redirects can be configured
 const CUSTOM_REDIRECTS_PATH = join(".", "_redirects");
 
@@ -37,4 +62,9 @@ module.exports = {
   NEXT_DIST_DIR,
   FUNCTION_TEMPLATE_PATH,
   CUSTOM_REDIRECTS_PATH,
+  NETLIFY_DEPLOY_FUNCTIONS,
+  NETLIFY_SPLIT_TEST_FUNCTIONS,
+  NETLIFY_FORM_FUNCTIONS,
+  NETLIFY_IDENTITY_FUNCTIONS,
+  NETLIFY_TRIGGER_FUNCTIONS,
 };

--- a/lib/helpers/getNetlifyFunctionName.js
+++ b/lib/helpers/getNetlifyFunctionName.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const isNetlifyTriggerFunction = require("./isNetlifyTriggerFunction");
 
 // Generate the Netlify Function name for the given file path.
 // The file path will be pages/directory/subdirectory/[id].js
@@ -17,14 +18,19 @@ const getNetlifyFunctionName = (filePath) => {
   // next/directory/page
   const filePathWithoutExtension = path.join("next", directoryPath, name);
 
-  // Replace slashes with underscores:
-  // next/directory/page > next_directory_page
-  let functionName = filePathWithoutExtension.split(path.sep).join("_");
+  let functionName;
+  if (isNetlifyTriggerFunction(name)) {
+    functionName = name;
+  } else {
+    // Replace slashes with underscores:
+    // next/directory/page > next_directory_page
+    functionName = filePathWithoutExtension.split(path.sep).join("_");
 
-  // Netlify Function names may not contain periods or square brackets.
-  // To be safe, we keep only alphanumeric characters and underscores.
-  // See: https://community.netlify.com/t/failed-to-upload-functions-file-function-too-large/3549/8
-  functionName = functionName.replace(/[^\w\d]/g, "");
+    // Netlify Function names may not contain periods or square brackets.
+    // To be safe, we keep only alphanumeric characters and underscores.
+    // See: https://community.netlify.com/t/failed-to-upload-functions-file-function-too-large/3549/8
+    functionName = functionName.replace(/[^\w\d]/g, "");
+  }
 
   return functionName;
 };

--- a/lib/helpers/getNetlifyFunctionName.js
+++ b/lib/helpers/getNetlifyFunctionName.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const isNetlifyTriggerFunction = require("./isNetlifyTriggerFunction");
+const { program } = require("commander");
 
 // Generate the Netlify Function name for the given file path.
 // The file path will be pages/directory/subdirectory/[id].js
@@ -19,7 +20,7 @@ const getNetlifyFunctionName = (filePath) => {
   const filePathWithoutExtension = path.join("next", directoryPath, name);
 
   let functionName;
-  if (isNetlifyTriggerFunction(name)) {
+  if (program.withTriggerFunctions && isNetlifyTriggerFunction(name)) {
     functionName = name;
   } else {
     // Replace slashes with underscores:

--- a/lib/helpers/isNetlifyTriggerFunction.js
+++ b/lib/helpers/isNetlifyTriggerFunction.js
@@ -1,0 +1,7 @@
+// Return true if the function is a Netlify Event Trigger Function
+const { NETLIFY_TRIGGER_FUNCTIONS } = require("../config");
+const isNetlifyTriggerRoute = (route) => {
+  return NETLIFY_TRIGGER_FUNCTIONS.includes(route);
+};
+
+module.exports = isNetlifyTriggerRoute;

--- a/next-on-netlify.js
+++ b/next-on-netlify.js
@@ -7,6 +7,10 @@ program
     "lines of build output to show for each section",
     50
   )
+  .option(
+    "--with-trigger-functions",
+    "Will parse functions that match Netlify Trigger Functions in 'pages/api/'"
+  )
   .parse(process.argv);
 
 const { logTitle } = require("./lib/helpers/logger");

--- a/tests/lib/helpers/isNetlifyTriggerFunction.test.js
+++ b/tests/lib/helpers/isNetlifyTriggerFunction.test.js
@@ -1,0 +1,10 @@
+const isNetlifyTriggerRoute = require("../../../lib/helpers/isNetlifyTriggerFunction");
+const { NETLIFY_TRIGGER_FUNCTIONS } = require("../../../lib/config");
+
+describe("isNetlifyTriggerRoute", () => {
+  test("returns true when is a Netlify Event Trigger Function", () => {
+    NETLIFY_TRIGGER_FUNCTIONS.forEach((trigger_event) => {
+      expect(isNetlifyTriggerRoute(trigger_event)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
This PR is a potential solution to #57 for support for **Netlify Event Trigger Functions** _out-of-the-box_ with a command flag.

## What it does?
We look to see if a function file name _somewhere_ (`pages/api/` or another directory) matches one of the Netlify Event Triggers. If so, we could copy it over and ensure the file name _stays the same_ is not formatted like other next functions that look like `next_api_helloworld.js`.

The big change here is if we find one of the [Netlify Trigger Event functions](https://docs.netlify.com/functions/trigger-on-events/#available-triggers) in `pages/api/` we don't change the format of the of the file we stick in `.netlify/functions`

## To Do
- [x] Find way to check for trigger event functions
- [x]  Skip formatting in `setupNetlifyFunctionForPage` if a fileName is an event trigger function
- [ ]  Write tests to verify it does the thing
  - Added Unit test to new helper, need to add integration test to verify it builds with expected output
- [x] Should this only run when passing in a flag?
  - Additionally we should probably add warning if you don't have the necessary canary installed (see gotcha comments in issue)

Demo app using this branch of `next-on-netlify`:
https://github.com/BrandonKlotz/netlify-identity-hooks