### PR TITLE
Add failing test for res.redirect

### DIFF
--- a/cypress/fixtures/pages/api/redirect.js
+++ b/cypress/fixtures/pages/api/redirect.js
@@ -1,0 +1,6 @@
+export default async function preview(req, res) {
+  const { query } = req;
+  const { to } = query;
+
+  res.redirect(`/redirectTest/${to}`);
+}

--- a/cypress/integration/default_spec.js
+++ b/cypress/integration/default_spec.js
@@ -535,6 +535,12 @@ describe("Preview Mode", () => {
     cy.url().should("include", "/previewTest/999");
   });
 
+  it("redirects to test page with res.redirect", () => {
+    cy.visit("/api/redirect?to=999");
+
+    cy.url().should("include", "/redirectTest/999");
+  });
+
   it("redirects to static preview test page", () => {
     cy.visit("/api/enterPreviewStatic");
 


### PR DESCRIPTION
Hi,

I was trying to deploy a Next site with preview mode on Netlify and was stuck on this error for quite some time:

![Screen Shot 2020-11-10 at 6 46 45 PM](https://user-images.githubusercontent.com/14029371/98809784-28740400-2444-11eb-83bb-6f76162cce85.png)

The final solution that resolved the issue was changing

```js
  res.redirect(req.query.slug)
```

to 

```js
  res.writeHead(307, { Location: req.query.slug });
  res.end();
```

I'm under the impression that the first syntax is supposed to be valid and was taken from the official Next.js [docs](https://nextjs.org/docs/advanced-features/preview-mode#step-1-create-and-access-a-preview-api-route) for preview mode. Hence, I've created a failing test so anyone here could take a look at the issue and find the root cause if interested.

Thanks and cheers!