### PR TITLE
Add CI tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,31 @@
+name: Tests
+on:
+  # Ensure GitHub actions are not run twice for same commits
+  push:
+    branches: [master]
+    tags: ["*"]
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node-version: [12.x, 14.x]
+        exclude:
+          - os: macOS-latest
+            node-version: 12.x
+      fail-fast: false
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Tests
+        run: npm test


### PR DESCRIPTION
This adds CI tests using GitHub actions copied from other Netlify projects.

This also allows us testing this code on Windows, which is important since many Netlify CLI users are on Windows. Tests on Windows are currently not enabled though, since they fail at the moment. We can add support for Windows in a follow-up PR.

Node `<12` does not seem to be currently supported, so CI tests are only running on Node 12 and 14. In a follow-up PR, we can add support for older Node.js versions, so it matches Netlify's officially supported Node.js versions.