### PR TITLE
Add support for Node `10.17.0`.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        node-version: [12.x, 14.x]
+        node-version: [10.17.0, 14.x]
         exclude:
           - os: macOS-latest
-            node-version: 12.x
+            node-version: 10.17.0
       fail-fast: false
     steps:
       - name: Git checkout
@@ -26,6 +26,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "hooks": {
       "pre-commit": "prettier --check ."
     }
+  },
+  "engines": {
+    "node": ">=10.17.0"
   }
 }

--- a/tests/helpers/buildNextApp.js
+++ b/tests/helpers/buildNextApp.js
@@ -19,9 +19,6 @@ const { NEXT_VERSION } = require("./nextVersion");
 // run next-on-netlify.
 
 class NextAppBuilder {
-  // Name of the app to build. This determines the build path.
-  __appName = null;
-
   // Set the application name. This determines the build path.
   forTest(testFile) {
     this.__appName = parse(testFile).name;


### PR DESCRIPTION
Node `10.17.0` could not run tests due to a test helpers using a JavaScript feature added in Node 12 (instance fields).
This PR fixes this.
It also runs tests on Node `10.17.0` and adds `engines.node` to declare the supported Node.js versions.