### PR TITLE
Upgrade version range of `next`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cypress:netlify:testonly": "env CYPRESS_SKIP_DEPLOY=true npm run cypress:netlify"
   },
   "peerDependencies": {
-    "next": "9.x"
+    "next": ">=9.5.3"
   },
   "devDependencies": {
     "cypress": "^5.1.0",


### PR DESCRIPTION
This upgrades the version range of `next`, following the discussion at https://github.com/netlify/netlify-plugin-nextjs/issues/25
See also https://github.com/netlify/netlify-plugin-nextjs/issues/42

I.e. `next-on-netlify` will not prevent Next.js 10 users from using this, but support is currently experimental.