### PR TITLE
Fix Node.js version in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,10 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        node-version: [10.17.0, 14.x]
+        # We should test on 10.13.0 but don't due to a bug in Jest
+        # https://github.com/facebook/jest/issues/9453
+        node-version: [10.15.0, 14.x]
         exclude:
           - os: macOS-latest
-            node-version: 10.17.0
+            node-version: 10.15.0
       fail-fast: false
     steps:
       - name: Git checkout


### PR DESCRIPTION
Fixed #87.

Unfortunately, we need to use Node `10.15.0` and not `10.13.0` because Jest `>=25` [has a bug with Node `<10.15.0`](https://github.com/facebook/jest/issues/9453), so that would force us to downgrade Jest two major releases down.

However, we should be just fine with testing `10.15.0`, not many big changes happened in-between those two versions.