### PR TITLE
Fix: Add support for res.redirect in API routes

### DIFF
--- a/cypress/fixtures/pages/api/redirect.js
+++ b/cypress/fixtures/pages/api/redirect.js
@@ -1,0 +1,6 @@
+export default async function preview(req, res) {
+  const { query } = req;
+  const { to } = query;
+
+  res.redirect(`/shows/${to}`);
+}

--- a/cypress/integration/default_spec.js
+++ b/cypress/integration/default_spec.js
@@ -526,6 +526,14 @@ describe("API endpoint", () => {
       );
     });
   });
+
+  it("redirects with res.redirect", () => {
+    cy.visit("/api/redirect?to=999");
+
+    cy.url().should("include", "/shows/999");
+    cy.get("h1").should("contain", "Show #999");
+    cy.get("p").should("contain", "Flash Gordon");
+  });
 });
 
 describe("Preview Mode", () => {

--- a/lib/templates/createResponseObject.js
+++ b/lib/templates/createResponseObject.js
@@ -24,6 +24,10 @@ const createResponseObject = ({ onResEnd }) => {
   res.writeHead = (status, headers) => {
     response.statusCode = status;
     if (headers) res.headers = Object.assign(res.headers, headers);
+
+    // Return res object to allow for chaining
+    // Fixes: https://github.com/netlify/next-on-netlify/pull/74
+    return res;
   };
   res.write = (chunk) => {
     if (!response.body) {


### PR DESCRIPTION
:warning: **MERGE THIS PR AFTER #92** :warning: 

This PR adds support for `res.redirect` in API routes as described in https://nextjs.org/docs/api-routes/response-helpers

It does this by returning the `res` object from `res.writeHead`, thus allowing method chaining. This is how a ServerResponse object should behave according to https://nodejs.org/api/http.html#http_response_writehead_statuscode_statusmessage_headers. The other mock methods of the `res` object probably need to be adjusted in the future, too.

This PR resolves #74 (thanks for the test case, @afzalsayed96! It's the first commit in this PR :slightly_smiling_face: ).