### PR TITLE
Add finished to res

### DIFF
--- a/lib/templates/createResponseObject.js
+++ b/lib/templates/createResponseObject.js
@@ -75,6 +75,7 @@ const createResponseObject = ({ onResEnd }) => {
       }
     }
 
+    res.finished = true;
     // Call onResEnd handler with the response object
     onResEnd(response);
   };

--- a/lib/templates/createResponseObject.js
+++ b/lib/templates/createResponseObject.js
@@ -76,6 +76,7 @@ const createResponseObject = ({ onResEnd }) => {
     }
 
     res.finished = true;
+    res.writableEnded = true;
     // Call onResEnd handler with the response object
     onResEnd(response);
   };


### PR DESCRIPTION
This signals to Next that we aren't expecting any props to be returned in `getServersideProps` or `getInitialProps`

Fixes: https://github.com/netlify/next-on-netlify/issues/116

I might've made a mistake to submit this PR from the GH-edit-UI, the labels didn't carry over 😅 

I've also added `writeableEnded` because [`finished` is deprecated](https://nodejs.org/api/http.html#http_response_finished)