### PR TITLE
Fix cypress:local: Skip test for cache control header

### DIFF
--- a/cypress/integration/optionalCatchAll_at_root_spec.js
+++ b/cypress/integration/optionalCatchAll_at_root_spec.js
@@ -104,9 +104,11 @@ describe("pre-rendered pages: /subfolder/[id].js", () => {
   });
 
   it("serves the pre-rendered HTML (and not the Netlify Function)", () => {
-    cy.request("/subfolder/static").then((response) => {
-      expect(response.headers["cache-control"]).to.include("public");
-    });
+    if (Cypress.env("DEPLOY") !== "local") {
+      cy.request("/subfolder/static").then((response) => {
+        expect(response.headers["cache-control"]).to.include("public");
+      });
+    }
   });
 });
 


### PR DESCRIPTION
This fixes a failing test when running `npm run cypress:local`.

The failing test is testing the cache control header of a pre-rendered, static page and expecting the headers to include "public". This is the case on netlify.app. However, in netlify dev this cache control header is not present, causing the test to fail.

For now, we simply skip the test when running the Cypress tests locally (as we do in `default_spec.js`). In the long term, we should probably set headers in a `_headers` file as suggested by https://github.com/netlify/next-on-netlify/issues/110.