### PR TITLE
hotfix: redirect.added was unreliable espec in tests

### DIFF
--- a/lib/steps/setupRedirects.js
+++ b/lib/steps/setupRedirects.js
@@ -36,10 +36,18 @@ const setupRedirects = (publishPath) => {
   // less-specific routes (e.g., catch-all)
   const sortedRoutes = getSortedRoutes(nextRedirects.map(({ route }) => route));
 
+  // There may be several redirects with the same route but different targets
+  const wasRedirectAdded = (redirect) => {
+    return redirects.find((addedRedirect) => {
+      const [route, target] = addedRedirect.split("  ");
+      return redirect.route === route && redirect.target === target;
+    });
+  };
+
   // Assemble redirects for each route
   sortedRoutes.forEach((route) => {
     const nextRedirect = nextRedirects.find(
-      (redirect) => redirect.route === route && !redirect.added
+      (redirect) => redirect.route === route && !wasRedirectAdded(redirect)
     );
 
     // One route may map to multiple Netlify routes: e.g., catch-all pages
@@ -60,8 +68,6 @@ const setupRedirects = (publishPath) => {
       const redirect = redirectPieces.join("  ").trim();
       logItem(redirect);
       redirects.push(redirect);
-      // Enables us to add colliding route redirects
-      nextRedirect.added = true;
     });
   });
 


### PR DESCRIPTION
if we hate this, we can update it in the future. right now i want to release the plugin and this was blocking the plugin tests - redirect.added was being remembered between each test and i couldnt figure out how to fix that within jest. i think this will probably be more reliable but yes, it's less clean.