### PR TITLE
track NoN files when configured dirs are used, clean before each new run

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,15 @@ const {
  *   publishDir: string to path
  * }
  */
+
 const nextOnNetlify = (options = {}) => {
   const functionsPath = options.functionsDir || NETLIFY_FUNCTIONS_PATH;
   const publishPath = options.publishDir || NETLIFY_PUBLISH_PATH;
 
-  prepareFolders({ functionsPath, publishPath });
+  const trackNextOnNetlifyFiles = prepareFolders({
+    functionsPath,
+    publishPath,
+  });
 
   copyPublicFiles(publishPath);
 
@@ -33,6 +37,8 @@ const nextOnNetlify = (options = {}) => {
   setupRedirects(publishPath);
 
   setupHeaders(publishPath);
+
+  trackNextOnNetlifyFiles();
 };
 
 module.exports = nextOnNetlify;

--- a/lib/helpers/handleFileTracking.js
+++ b/lib/helpers/handleFileTracking.js
@@ -1,0 +1,80 @@
+const { join } = require("path");
+const {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  removeSync,
+} = require("fs-extra");
+const findCacheDir = require("find-cache-dir");
+const { NETLIFY_PUBLISH_PATH, NETLIFY_FUNCTIONS_PATH } = require("../config");
+
+const TRACKING_FILE_SEPARATOR = "---";
+
+// Clean configured publish and functions folders and track next-on-netlify files
+// for future cleans
+const handleFileTracking = ({ functionsPath, publishPath }) => {
+  const isConfiguredFunctionsDir = functionsPath !== NETLIFY_FUNCTIONS_PATH;
+  const isConfiguredPublishDir = publishPath !== NETLIFY_PUBLISH_PATH;
+
+  const cacheDir = findCacheDir({ name: "next-on-netlify", create: true });
+  const trackingFilePath = join(cacheDir, ".nonfiletracking");
+
+  if (existsSync(trackingFilePath)) {
+    const trackingFile = readFileSync(trackingFilePath, "utf8");
+    const [trackedFunctions, trackedPublish] = trackingFile.split(
+      TRACKING_FILE_SEPARATOR
+    );
+
+    const cleanConfiguredFiles = (trackedFiles) => {
+      trackedFiles.forEach((file) => {
+        const filePath = join(publishPath, file);
+        if (file !== "" && existsSync(filePath)) {
+          removeSync(filePath);
+        }
+      });
+    };
+
+    if (isConfiguredPublishDir) {
+      cleanConfiguredFiles(trackedPublish.split("\n"));
+    }
+    if (isConfiguredFunctionsDir) {
+      cleanConfiguredFiles(trackedFunctions.split("\n"));
+    }
+  }
+
+  const functionsBeforeRun = existsSync(functionsPath)
+    ? readdirSync(functionsPath)
+    : [];
+  const publishBeforeRun = existsSync(publishPath)
+    ? readdirSync(publishPath)
+    : [];
+
+  // this callback will run at the end of nextOnNetlify()
+  const trackNewFiles = () => {
+    const functionsAfterRun = isConfiguredFunctionsDir
+      ? readdirSync(functionsPath)
+      : functionsBeforeRun;
+    const publishAfterRun = isConfiguredPublishDir
+      ? readdirSync(publishPath)
+      : publishBeforeRun;
+    const getDifference = (before, after) =>
+      after.filter((filePath) => !before.includes(filePath));
+    const newFunctionsFiles = getDifference(
+      functionsBeforeRun,
+      functionsAfterRun
+    );
+    const newPublishFiles = getDifference(publishBeforeRun, publishAfterRun);
+
+    const allTrackedFiles = [
+      ...newFunctionsFiles,
+      TRACKING_FILE_SEPARATOR,
+      ...newPublishFiles,
+    ];
+    writeFileSync(trackingFilePath, allTrackedFiles.join("\n"));
+  };
+
+  return trackNewFiles;
+};
+
+module.exports = handleFileTracking;

--- a/lib/steps/prepareFolders.js
+++ b/lib/steps/prepareFolders.js
@@ -1,8 +1,19 @@
-const { emptyDirSync } = require("fs-extra");
+const { join } = require("path");
+const {
+  emptyDirSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  removeSync,
+} = require("fs-extra");
+const findCacheDir = require("find-cache-dir");
 const { logTitle, log } = require("../helpers/logger");
 const { NETLIFY_PUBLISH_PATH, NETLIFY_FUNCTIONS_PATH } = require("../config");
 
-// Empty existing publish and functions folders
+const TRACKING_FILE_SEPARATOR = "---";
+
+// Clean existing publish and functions folders
 const prepareFolders = ({ functionsPath, publishPath }) => {
   logTitle("🚀 Next on Netlify 🚀");
 
@@ -19,8 +30,66 @@ const prepareFolders = ({ functionsPath, publishPath }) => {
     log("  ", "Make sure these are set in your netlify.toml file.");
   }
 
-  if (publishPath === NETLIFY_PUBLISH_PATH) emptyDirSync(publishPath);
-  if (functionsPath === NETLIFY_FUNCTIONS_PATH) emptyDirSync(functionsPath);
+  const cacheDir = findCacheDir({ name: "next-on-netlify", create: true });
+  const trackingFilePath = join(cacheDir, ".nonfiletracking");
+  const trackingFile = existsSync(trackingFilePath)
+    ? readFileSync(trackingFilePath, "utf8")
+    : "---";
+
+  const [trackedFunctions, trackedPublish] = trackingFile.split("---");
+  const isConfiguredPublishDir = publishPath !== NETLIFY_PUBLISH_PATH;
+  const isConfiguredFunctionsDir = functionsPath !== NETLIFY_FUNCTIONS_PATH;
+
+  if (isConfiguredPublishDir) {
+    trackedPublish
+      .trim()
+      .split("\n")
+      .forEach((file) => {
+        const filePath = join(publishPath, file);
+        if (existsSync(filePath) && file !== "") {
+          removeSync(filePath);
+        }
+      });
+  } else {
+    emptyDirSync(publishPath);
+  }
+  if (isConfiguredFunctionsDir) {
+    trackedFunctions
+      .trim()
+      .split("\n")
+      .forEach((file) => {
+        const filePath = join(functionsPath, file);
+        if (existsSync(filePath) && file !== "") {
+          removeSync(filePath);
+        }
+      });
+  } else {
+    emptyDirSync(functionsPath);
+  }
+
+  const functionsBeforeRun = existsSync(functionsPath)
+    ? readdirSync(functionsPath)
+    : [];
+  const publishBeforeRun = existsSync(publishPath)
+    ? readdirSync(publishPath)
+    : [];
+
+  // this callback will run at the end of nextOnNetlify()
+  return () => {
+    const functionsAfterRun = isConfiguredFunctionsDir
+      ? readdirSync(functionsPath)
+      : functionsBeforeRun;
+    const publishAfterRun = isConfiguredPublishDir
+      ? readdirSync(publishPath)
+      : publishBeforeRun;
+    const getDiff = (before, after) =>
+      after.filter((filePath) => !before.includes(filePath));
+    const functionsDiff = getDiff(functionsBeforeRun, functionsAfterRun);
+    const publishDiff = getDiff(publishBeforeRun, publishAfterRun);
+
+    const totalFilesDiff = [...functionsDiff, "---", ...publishDiff];
+    writeFileSync(trackingFilePath, totalFilesDiff.join("\n"));
+  };
 };
 
 module.exports = prepareFolders;

--- a/lib/steps/prepareFolders.js
+++ b/lib/steps/prepareFolders.js
@@ -1,95 +1,37 @@
 const { join } = require("path");
-const {
-  emptyDirSync,
-  existsSync,
-  readdirSync,
-  readFileSync,
-  writeFileSync,
-  removeSync,
-} = require("fs-extra");
+const { emptyDirSync } = require("fs-extra");
 const findCacheDir = require("find-cache-dir");
 const { logTitle, log } = require("../helpers/logger");
 const { NETLIFY_PUBLISH_PATH, NETLIFY_FUNCTIONS_PATH } = require("../config");
-
-const TRACKING_FILE_SEPARATOR = "---";
+const handleFileTracking = require("../helpers/handleFileTracking");
 
 // Clean existing publish and functions folders
 const prepareFolders = ({ functionsPath, publishPath }) => {
   logTitle("🚀 Next on Netlify 🚀");
 
-  if (functionsPath === NETLIFY_FUNCTIONS_PATH) {
+  const isNotConfiguredFunctionsDir = functionsPath === NETLIFY_FUNCTIONS_PATH;
+  const isNotConfiguredPublishDir = publishPath === NETLIFY_PUBLISH_PATH;
+
+  if (isNotConfiguredFunctionsDir) {
     log("  ", "Functions directory: ", functionsPath);
   }
-  if (publishPath === NETLIFY_PUBLISH_PATH) {
+  if (isNotConfiguredPublishDir) {
     log("  ", "Publish directory: ", publishPath);
   }
-  if (
-    functionsPath === NETLIFY_FUNCTIONS_PATH ||
-    publishPath === NETLIFY_PUBLISH_PATH
-  ) {
+  if (isNotConfiguredFunctionsDir || isNotConfiguredPublishDir) {
     log("  ", "Make sure these are set in your netlify.toml file.");
   }
 
-  const cacheDir = findCacheDir({ name: "next-on-netlify", create: true });
-  const trackingFilePath = join(cacheDir, ".nonfiletracking");
-  const trackingFile = existsSync(trackingFilePath)
-    ? readFileSync(trackingFilePath, "utf8")
-    : "---";
-
-  const [trackedFunctions, trackedPublish] = trackingFile.split("---");
-  const isConfiguredPublishDir = publishPath !== NETLIFY_PUBLISH_PATH;
-  const isConfiguredFunctionsDir = functionsPath !== NETLIFY_FUNCTIONS_PATH;
-
-  if (isConfiguredPublishDir) {
-    trackedPublish
-      .trim()
-      .split("\n")
-      .forEach((file) => {
-        const filePath = join(publishPath, file);
-        if (existsSync(filePath) && file !== "") {
-          removeSync(filePath);
-        }
-      });
-  } else {
+  // We can empty these dirs knowing there will only be stale NoN-generated files inside
+  if (isNotConfiguredPublishDir) {
     emptyDirSync(publishPath);
   }
-  if (isConfiguredFunctionsDir) {
-    trackedFunctions
-      .trim()
-      .split("\n")
-      .forEach((file) => {
-        const filePath = join(functionsPath, file);
-        if (existsSync(filePath) && file !== "") {
-          removeSync(filePath);
-        }
-      });
-  } else {
+  if (isNotConfiguredFunctionsDir) {
     emptyDirSync(functionsPath);
   }
 
-  const functionsBeforeRun = existsSync(functionsPath)
-    ? readdirSync(functionsPath)
-    : [];
-  const publishBeforeRun = existsSync(publishPath)
-    ? readdirSync(publishPath)
-    : [];
-
-  // this callback will run at the end of nextOnNetlify()
-  return () => {
-    const functionsAfterRun = isConfiguredFunctionsDir
-      ? readdirSync(functionsPath)
-      : functionsBeforeRun;
-    const publishAfterRun = isConfiguredPublishDir
-      ? readdirSync(publishPath)
-      : publishBeforeRun;
-    const getDiff = (before, after) =>
-      after.filter((filePath) => !before.includes(filePath));
-    const functionsDiff = getDiff(functionsBeforeRun, functionsAfterRun);
-    const publishDiff = getDiff(publishBeforeRun, publishAfterRun);
-
-    const totalFilesDiff = [...functionsDiff, "---", ...publishDiff];
-    writeFileSync(trackingFilePath, totalFilesDiff.join("\n"));
-  };
+  // This returns a function that runs as the last step of nextOnNetlify()
+  return handleFileTracking({ functionsPath, publishPath });
 };
 
 module.exports = prepareFolders;

--- a/tests/configurableDirs.test.js
+++ b/tests/configurableDirs.test.js
@@ -25,6 +25,7 @@ beforeAll(
       .withPages("pages")
       .withNextConfig("next.config.js")
       .withPackageJson("package.json")
+      .withCustomFunctions("my-functions")
       .runWithRequire({ functionsDir: FUNCTIONS_DIR, publishDir: PUBLISH_DIR });
   },
   // time out after 180 seconds
@@ -36,6 +37,10 @@ describe("next-on-netlify", () => {
 
   test("builds successfully", () => {
     expect(runOutput).toMatch("Built successfully!");
+  });
+
+  test("copies custom Netlify Function to configured functions directory", () => {
+    expect(existsSync(join(functionsDir, "someTestFunction.js"))).toBe(true);
   });
 
   test("creates a Netlify Function for each SSR page", () => {
@@ -125,8 +130,9 @@ describe("clean up of NoN files", () => {
       "next_shows_id",
       "next_shows_params",
     ];
-    const fileListFunctions = fileList.split("---")[0].trim().split("\n");
+    const fileListFunctions = fileList.split("---")[0].split("\n");
     expect(isSameList(nextFunctions, fileListFunctions)).toBe(true);
+    expect(fileListFunctions.includes("someTestFunction.js")).toBe(false);
     const publishFiles = [
       "404.html",
       "_next",
@@ -135,7 +141,7 @@ describe("clean up of NoN files", () => {
       "static",
       "static.html",
     ];
-    const fileListPublish = fileList.split("---")[1].trim().split("\n");
+    const fileListPublish = fileList.split("---")[1].split("\n");
     expect(isSameList(publishFiles, fileListPublish)).toBe(true);
   });
 });

--- a/tests/configurableDirs.test.js
+++ b/tests/configurableDirs.test.js
@@ -1,0 +1,141 @@
+// Test next-on-netlify when config is set from a function in next.config.js
+// See: https://github.com/netlify/next-on-netlify/issues/25
+
+const { parse, join } = require("path");
+const { existsSync, readdirSync, readFileSync } = require("fs-extra");
+const buildNextApp = require("./helpers/buildNextApp");
+
+// The name of this test file (without extension)
+const FILENAME = parse(__filename).name;
+
+// The directory which will be used for testing.
+// We simulate a NextJS app within that directory, with pages, and a
+// package.json file.
+const PROJECT_PATH = join(__dirname, "builds", FILENAME);
+const FUNCTIONS_DIR = "my-functions";
+const PUBLISH_DIR = "my-publish";
+
+// Capture the output to verify successful build
+let buildOutput;
+
+beforeAll(
+  async () => {
+    runOutput = await buildNextApp()
+      .forTest(__filename)
+      .withPages("pages")
+      .withNextConfig("next.config.js")
+      .withPackageJson("package.json")
+      .runWithRequire({ functionsDir: FUNCTIONS_DIR, publishDir: PUBLISH_DIR });
+  },
+  // time out after 180 seconds
+  180 * 1000
+);
+
+describe("next-on-netlify", () => {
+  const functionsDir = join(PROJECT_PATH, FUNCTIONS_DIR);
+
+  test("builds successfully", () => {
+    expect(runOutput).toMatch("Built successfully!");
+  });
+
+  test("creates a Netlify Function for each SSR page", () => {
+    expect(existsSync(join(functionsDir, "next_index", "next_index.js"))).toBe(
+      true
+    );
+    expect(
+      existsSync(join(functionsDir, "next_shows_id", "next_shows_id.js"))
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(functionsDir, "next_shows_params", "next_shows_params.js")
+      )
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(
+          functionsDir,
+          "next_getServerSideProps_static",
+          "next_getServerSideProps_static.js"
+        )
+      )
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(
+          functionsDir,
+          "next_getServerSideProps_id",
+          "next_getServerSideProps_id.js"
+        )
+      )
+    ).toBe(true);
+  });
+
+  test("copies static pages to output directory", () => {
+    const OUTPUT_PATH = join(PROJECT_PATH, PUBLISH_DIR);
+
+    expect(existsSync(join(OUTPUT_PATH, "static.html"))).toBe(true);
+    expect(existsSync(join(OUTPUT_PATH, "static/[id].html"))).toBe(true);
+  });
+
+  test("copies static assets to out_publish/_next/ directory", () => {
+    const dirs = readdirSync(
+      join(PROJECT_PATH, PUBLISH_DIR, "_next", "static")
+    );
+
+    expect(dirs.length).toBe(2);
+    expect(dirs).toContain("chunks");
+  });
+});
+
+describe("clean up of NoN files", () => {
+  test("creates a .nonfiletracking to audit NoN-specific files between builds", () => {
+    const cacheDir = join(PROJECT_PATH, "/node_modules/.cache/next-on-netlify");
+    const dirs = readdirSync(cacheDir);
+    expect(dirs[0]).toEqual(".nonfiletracking");
+  });
+
+  test(".nonfiletracking contains NoN-specific files", () => {
+    const cacheDir = join(PROJECT_PATH, "/node_modules/.cache/next-on-netlify");
+    const fileList = readFileSync(join(cacheDir, ".nonfiletracking"), "utf8");
+    // had to test equality this way because of windows :)
+    const isSameList = (arr1, arr2) =>
+      arr1.reduce((isSame, func) => {
+        if (arr2.includes(func)) {
+          isSame = true;
+        } else {
+          isSame = false;
+        }
+        return isSame;
+      }, true);
+    const nextFunctions = [
+      "next_api_shows_id",
+      "next_api_shows_params",
+      "next_api_static",
+      "next_getServerSideProps_all_slug",
+      "next_getServerSideProps_id",
+      "next_getServerSideProps_static",
+      "next_getStaticProps_id",
+      "next_getStaticProps_static",
+      "next_getStaticProps_withFallback_id",
+      "next_getStaticProps_withFallback_slug",
+      "next_getStaticProps_withRevalidate_id",
+      "next_getStaticProps_withRevalidate_withFallback_id",
+      "next_getStaticProps_withrevalidate",
+      "next_index",
+      "next_shows_id",
+      "next_shows_params",
+    ];
+    const fileListFunctions = fileList.split("---")[0].trim().split("\n");
+    expect(isSameList(nextFunctions, fileListFunctions)).toBe(true);
+    const publishFiles = [
+      "404.html",
+      "_next",
+      "_redirects",
+      "getStaticProps",
+      "static",
+      "static.html",
+    ];
+    const fileListPublish = fileList.split("---")[1].trim().split("\n");
+    expect(isSameList(publishFiles, fileListPublish)).toBe(true);
+  });
+});


### PR DESCRIPTION
this is a pass at tracking NoN-moved or NoN-generated files between runs of NoN and cleaning them before a new run.

i don't see a way we can add a "manual" clean option for plugin CLI users. for example, if they build on the CLI four consecutive times, this change should allow them to do that without having to change our file overwrite logic at all. BUT, when they're done building/deploying on the CLI, they will be left with all the NoN files in their .git, as @FinnWoelm pointed out in the original issue that has since been transferred internally. because the plugin will only run on `netlify build`, i don't think adding a "clean" flag/command to NoN will make a difference; there'd be no way for the plugin to access it outside of a build. these users will have to stash or manually delete these files after finishing their builds/deploys. open to ideas here. this may be a greater CLI issue.

to-do:

- [x] test with plugin
- [ ] write cleanup script

