### PR TITLE
next/image support back after internal functions dep work

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,7 @@ const nextOnNetlify = (options = {}) => {
 
   setupPages({ functionsPath, publishPath });
 
-  // TO-DO: put back when jimp module issue is resolved ;(
-  // setupImageFunction(functionsPath);
+  setupImageFunction(functionsPath);
 
   setupRedirects(publishPath);
 

--- a/tests/defaults.test.js
+++ b/tests/defaults.test.js
@@ -135,10 +135,9 @@ describe("API Pages", () => {
 describe("next/image", () => {
   const functionsDir = join(PROJECT_PATH, "out_functions");
 
-  // TO-DO: put back when jump module issue is resolved ;(
-  // test("sets up next_image as a function in every project by default", () => {
-  //   expect(existsSync(join(functionsDir, "next_image.js"))).toBe(true);
-  // });
+  test("sets up next_image as a function in every project by default", () => {
+    expect(existsSync(join(functionsDir, "next_image.js"))).toBe(true);
+  });
 });
 
 describe("SSG Pages with getStaticProps", () => {


### PR DESCRIPTION
Fixes https://github.com/netlify/next-on-netlify/issues/143 (really 143 is fixed by erez's function deps work internally), this just puts next/image support back