### PR TITLE
chore: support Node 15

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # We should test on 10.13.0 but don't due to a bug in Jest
         # https://github.com/facebook/jest/issues/9453
-        node-version: [10.15.0, 14.x]
+        node-version: [10.15.0, 15.x]
         exclude:
           - os: macOS-latest
             node-version: 10.15.0


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/1

This tests Node 15 in CI.
