### PR TITLE
More priority for deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Deprecating next-on-netlify
+
+We are deprecating `next-on-netlify` in favor of Netlify's [Essential Next.js Build Plugin](https://github.com/netlify/netlify-plugin-nextjs). Please visit [this issue](https://github.com/netlify/next-on-netlify/issues/176) to learn more about the deprecation of `next-on-netlify` and ask any questions. You can also visit our simple [Migration doc](https://github.com/netlify/next-on-netlify/blob/main/MIGRATING.md) for assistance migrating to the plugin.
+
+- Build Plugin [@netlify/plugin-nextjs](https://github.com/netlify/netlify-plugin-nextjs)
+- [Plugin npm package](https://www.npmjs.com/package/@netlify/plugin-nextjs)
+
 ![Next.js on Netlify](next-on-netlify.png)
 
 <p align="center">
@@ -16,13 +23,6 @@
 </p>
 
 `next-on-netlify` is a utility for enabling server-side rendering in Next.js on Netlify. It wraps your application in a tiny compatibility layer, so that pages can use Netlify Functions to be server-side rendered.
-
-## Deprecating next-on-netlify
-
-We are deprecating `next-on-netlify` in favor of Netlify's [Essential Next.js Build Plugin](https://github.com/netlify/netlify-plugin-nextjs). Please visit [this issue](https://github.com/netlify/next-on-netlify/issues/176) to learn more about the deprecation of `next-on-netlify` and ask any questions. You can also visit our simple [Migration doc](https://github.com/netlify/next-on-netlify/blob/main/MIGRATING.md) for assistance migrating to the plugin.
-
-- Build Plugin [@netlify/plugin-nextjs](https://github.com/netlify/netlify-plugin-nextjs)
-- [Plugin npm package](https://www.npmjs.com/package/@netlify/plugin-nextjs)
 
 
 ## Table of Contents


### PR DESCRIPTION
I wanted to install the plugin, but it didn't work because it was not clear this plugin was deprecated. 

So I think it will be a good idea to move the deprecation message on the top, so it's the first thing people see.

If you don't agree, no hard feelings 😅